### PR TITLE
ci: release schedule test

### DIFF
--- a/.github/workflows/release_pr.yaml
+++ b/.github/workflows/release_pr.yaml
@@ -2,7 +2,7 @@ name: PR to trigger release
 
 "on":
   schedule:
-    - cron: "11 05 * * 2"
+    - cron: "10 20 * * 2"
 
 jobs:
   pull-request:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,7 +12,7 @@ env:
   PYTHON_VERSION_DEFAULT: "3.10.8"
 
 jobs:
-  release:
+  tag:
     runs-on: ubuntu-latest
     concurrency: release
     environment: PyPI


### PR DESCRIPTION
Change the time to h-1 as github runners run on UTC, not UK